### PR TITLE
add capability to 'use' routes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -229,8 +229,17 @@ Router.prototype.del = Router.prototype['delete'];
  * @returns {Router}
  */
 
-Router.prototype.use = function (middleware) {
-  this.stack.middleware.push.apply(this.stack.middleware, arguments);
+Router.prototype.use = function (path,middleware) {
+  var middlewares = [];
+  Array.prototype.push.apply(middlewares,arguments);
+  if (typeof path === 'string') {
+    middlewares.shift();
+    var args=[path,this.methods];
+    Array.prototype.push.apply(args,middlewares);
+    this.register.apply(this,args);
+  } else {
+    this.stack.middleware.push.apply(this.stack.middleware, arguments);
+  }
   return this;
 };
 


### PR DESCRIPTION
modified Router.prototype.use to take path as an optional parameters, so it would be parsed as routes ( but with all methods registered).